### PR TITLE
Fix year inconsistencies in GLIMS notebook

### DIFF
--- a/GLIMS format for submitting.ipynb
+++ b/GLIMS format for submitting.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# USER INPUT BLOCK  ✏️\n",
+    "# USER INPUT BLOCK  \u270f\ufe0f\n",
     "glacier_name = \"Turner\"  # name of the glacier\n",
     "\n",
     "# input folders\n",
@@ -44,12 +44,12 @@
     "out_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "# file paths\n",
-    "outline58_fp = base_dir   / f\"{glacier_name}1960.shp\"\n",
+    "outline58_fp = base_dir   / f\"{glacier_name}1958.shp\"\n",
     "outline23_fp = base_dir   / f\"{glacier_name}2023.shp\"\n",
-    "cl58_fp      = center_dir / f\"{glacier_name}1960_Centerlines_smooth.shp\"\n",
+    "cl58_fp      = center_dir / f\"{glacier_name}1958_Centerlines_smooth.shp\"\n",
     "cl23_fp      = center_dir / f\"{glacier_name}2023_Centerlines_smooth.shp\"\n",
     "\n",
-    "meta1958 = dict(orig_id=\"A16817\", acq_time=\"1959-09-06\", inst_name=\"Historical Aerial Photo from  National Air Photo Library (NAPL)\")\n",
+    "meta1958 = dict(orig_id=\"A16817\", acq_time=\"1958-09-06\", inst_name=\"Historical Aerial Photo from  National Air Photo Library (NAPL)\")\n",
     "meta2023 = dict(orig_id=\"20230817_154317_42_2424\", acq_time=\"2023-08-17\", inst_name=\"PlanetScope Satellite Imagery\")\n",
     "\n",
     "analysis_info = dict(\n",
@@ -177,18 +177,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loading input layers …\n",
-      "Repairing geometry & reprojecting …\n"
+      "Loading input layers \u2026\n",
+      "Repairing geometry & reprojecting \u2026\n"
      ]
     }
    ],
    "source": [
     "# PROCESS\n",
-    "print(\"Loading input layers …\")\n",
+    "print(\"Loading input layers \u2026\")\n",
     "gdf58_raw = read_vector(outline58_fp)\n",
     "gdf23_raw = read_vector(outline23_fp)\n",
     "\n",
-    "print(\"Repairing geometry & reprojecting …\")\n",
+    "print(\"Repairing geometry & reprojecting \u2026\")\n",
     "gdf58 = add_attrs(to_wgs84(fix_polygons(gdf58_raw)), meta1958,\n",
     "                  loc_unc_val=UNC58_LOC,  glob_unc_val=UNC58_GLOB)\n",
     "gdf23 = add_attrs(to_wgs84(fix_polygons(gdf23_raw)), meta2023,\n",
@@ -208,10 +208,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✔ wrote D:\\outputforGLIMS\\Fork\\Fork1959.shp\n",
-      "✔ wrote D:\\outputforGLIMS\\Fork\\Fork2023.shp\n",
-      "✔ wrote D:\\outputforGLIMS\\Fork\\Fork1959_centerline.shp\n",
-      "✔ wrote D:\\outputforGLIMS\\Fork\\Fork2023_centerline.shp\n",
+      "\u2714 wrote D:\\outputforGLIMS\\Fork\\Fork1959.shp\n",
+      "\u2714 wrote D:\\outputforGLIMS\\Fork\\Fork2023.shp\n",
+      "\u2714 wrote D:\\outputforGLIMS\\Fork\\Fork1959_centerline.shp\n",
+      "\u2714 wrote D:\\outputforGLIMS\\Fork\\Fork2023_centerline.shp\n",
       "\n",
       "All four layers are GLIMS-ready and stored in D:\\outputforGLIMS\\Fork\n"
      ]
@@ -221,27 +221,27 @@
      "output_type": "stream",
      "text": [
       "C:\\Users\\WilsonSIRL5-MCY-E113\\AppData\\Local\\Temp\\ipykernel_18636\\3998575474.py:7: UserWarning: Column names longer than 10 characters will be truncated when saved to ESRI Shapefile.\n",
-      "  gdf58.to_file(out58_fp); print(\"✔ wrote\", out58_fp)\n",
+      "  gdf58.to_file(out58_fp); print(\"\u2714 wrote\", out58_fp)\n",
       "C:\\Users\\WilsonSIRL5-MCY-E113\\AppData\\Local\\Temp\\ipykernel_18636\\3998575474.py:8: UserWarning: Column names longer than 10 characters will be truncated when saved to ESRI Shapefile.\n",
-      "  gdf23.to_file(out23_fp); print(\"✔ wrote\", out23_fp)\n",
+      "  gdf23.to_file(out23_fp); print(\"\u2714 wrote\", out23_fp)\n",
       "C:\\Users\\WilsonSIRL5-MCY-E113\\AppData\\Local\\Temp\\ipykernel_18636\\3998575474.py:9: UserWarning: Column names longer than 10 characters will be truncated when saved to ESRI Shapefile.\n",
-      "  cl58 .to_file(cl58_out); print(\"✔ wrote\", cl58_out)\n",
+      "  cl58 .to_file(cl58_out); print(\"\u2714 wrote\", cl58_out)\n",
       "C:\\Users\\WilsonSIRL5-MCY-E113\\AppData\\Local\\Temp\\ipykernel_18636\\3998575474.py:10: UserWarning: Column names longer than 10 characters will be truncated when saved to ESRI Shapefile.\n",
-      "  cl23 .to_file(cl23_out); print(\"✔ wrote\", cl23_out)\n"
+      "  cl23 .to_file(cl23_out); print(\"\u2714 wrote\", cl23_out)\n"
      ]
     }
    ],
    "source": [
     "# EXPORT\n",
-    "out58_fp = out_dir / f\"{glacier_name}1959.shp\"\n",
+    "out58_fp = out_dir / f\"{glacier_name}1958.shp\"\n",
     "out23_fp = out_dir / f\"{glacier_name}2023.shp\"\n",
-    "cl58_out = out_dir / f\"{glacier_name}1959_centerline.shp\"\n",
+    "cl58_out = out_dir / f\"{glacier_name}1958_centerline.shp\"\n",
     "cl23_out = out_dir / f\"{glacier_name}2023_centerline.shp\"\n",
     "\n",
-    "gdf58.to_file(out58_fp); print(\"✔ wrote\", out58_fp)\n",
-    "gdf23.to_file(out23_fp); print(\"✔ wrote\", out23_fp)\n",
-    "cl58 .to_file(cl58_out); print(\"✔ wrote\", cl58_out)\n",
-    "cl23 .to_file(cl23_out); print(\"✔ wrote\", cl23_out)\n",
+    "gdf58.to_file(out58_fp); print(\"\u2714 wrote\", out58_fp)\n",
+    "gdf23.to_file(out23_fp); print(\"\u2714 wrote\", out23_fp)\n",
+    "cl58 .to_file(cl58_out); print(\"\u2714 wrote\", cl58_out)\n",
+    "cl23 .to_file(cl23_out); print(\"\u2714 wrote\", cl23_out)\n",
     "\n",
     "print(\"\\nAll four layers are GLIMS-ready and stored in\", out_dir)"
    ]


### PR DESCRIPTION
## Summary
- fix incorrect year in shapefile paths and export filenames
- adjust metadata acquisition year

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b35d7df30832fbdf791c13341eed1